### PR TITLE
Support for CORS

### DIFF
--- a/config.php
+++ b/config.php
@@ -8,5 +8,8 @@ return (object) array(
             'secret' => 'your-client-secret or access-key'
         ),
         // (object) array(...)
-    )
+    ),
+    'allowedOrigins' => array(
+        // 'https://your-domain.com'
+    ),
 );

--- a/p/cors.php
+++ b/p/cors.php
@@ -1,0 +1,15 @@
+<?php
+
+// Set CORS headers with every response
+$config = include('../config.php');
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+if (in_array($origin, $config->allowedOrigins, true)) {
+    header("Access-Control-Allow-Origin: $origin");
+    header("Access-Control-Allow-Credentials: true");
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
+    header("Access-Control-Allow-Headers: Content-Type");
+    exit;
+}

--- a/p/proxy.php
+++ b/p/proxy.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__.'/../vendor/autoload.php';
+require_once __DIR__.'/cors.php';
 
 function sendHit() {
     try {


### PR DESCRIPTION
When running this proxy on a different (sub-)domain, no `Allow-Access-Control-Origin` header is sent. Hence, the proxy cannot be used without further configuration.
In this PR, I've added basic CORS configuration and (preflight) handling.